### PR TITLE
feature: adds GET for todo list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,13 @@ comandos_cli.txt
 
 .terraform.lock.hcl
 
+### PYTHON ###
+.pytest_cache/
+__pycache__/
+
+### Virtual environments ###
+venv/
+ENV/
+env/
+.env/
+.venv/

--- a/src/lambda/todo-list/list_items/list_items_handler.py
+++ b/src/lambda/todo-list/list_items/list_items_handler.py
@@ -1,0 +1,19 @@
+import os
+import json
+import boto3
+from boto3.dynamodb.conditions import Key
+
+
+def lambda_handler(event, context):
+    try:
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(os.environ["DYNAMODB_TABLE_NAME"])
+        user_id = event["requestContext"]["authorizer"]["jwt"]["claims"]["sub"]
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with("ITEM#")
+        )
+        items = response.get("Items", [])
+        return {"statusCode": 200, "body": json.dumps({"tasks": items})}
+    except Exception as e:
+        return {"statusCode": 500, "body": json.dumps({"error": str(e)})}

--- a/src/lambda/todo-list/list_items/test_list_items_handler.py
+++ b/src/lambda/todo-list/list_items/test_list_items_handler.py
@@ -1,0 +1,50 @@
+import os
+import json
+import pytest
+from list_items_handler import lambda_handler
+
+
+def test_success(monkeypatch):
+    os.environ["DYNAMODB_TABLE_NAME"] = "fake-table"
+
+    class FakeTable:
+        def query(self, KeyConditionExpression):
+            return {
+                "Items": [{"PK": "USER#123", "SK": "ITEM#001", "title": "Buy milk"}]
+            }
+
+    class FakeDynamoDB:
+        def Table(self, name):
+            return FakeTable()
+
+    monkeypatch.setattr(
+        "list_items_handler.boto3.resource", lambda service: FakeDynamoDB()
+    )
+
+    event = {"requestContext": {"authorizer": {"jwt": {"claims": {"sub": "123"}}}}}
+
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 200
+    assert "Buy milk" in response["body"]
+
+
+def test_failure(monkeypatch):
+    os.environ["DYNAMODB_TABLE_NAME"] = "fake-table"
+
+    class FakeTable:
+        def query(self, KeyConditionExpression):
+            raise Exception("Dynamo error")
+
+    class FakeDynamoDB:
+        def Table(self, name):
+            return FakeTable()
+
+    monkeypatch.setattr(
+        "list_items_handler.boto3.resource", lambda service: FakeDynamoDB()
+    )
+
+    event = {"requestContext": {"authorizer": {"jwt": {"claims": {"sub": "123"}}}}}
+
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 500
+    assert "Dynamo error" in response["body"]

--- a/terraform/modules/apigateway/main.tf
+++ b/terraform/modules/apigateway/main.tf
@@ -67,3 +67,33 @@ resource "aws_lambda_permission" "api_gw_lambda_permission" {
 
   source_arn = "${aws_apigatewayv2_api.api.execution_arn}/*/*/hello"
 }
+
+resource "aws_apigatewayv2_route" "list_items_route" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "GET /lista-tarefa"
+
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito_authorizer.id
+
+  target = "integrations/${aws_apigatewayv2_integration.list_items_integration.id}"
+}
+
+resource "aws_apigatewayv2_integration" "list_items_integration" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = var.list_items_function_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+resource "aws_lambda_permission" "list_items_api_permission" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = var.list_items_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*/lista-tarefa"
+}
+
+output "api_url" {
+  value = aws_apigatewayv2_stage.stage.invoke_url
+}

--- a/terraform/modules/apigateway/variables.tf
+++ b/terraform/modules/apigateway/variables.tf
@@ -2,3 +2,15 @@ variable "region" {}
 variable "lambda_function_arn" {}
 variable "user_pool_id" {}
 variable "user_pool_client_id" {}
+variable "lambda_function_name" {
+  type = string
+}
+variable "list_items_function_arn" {
+  type = string
+}
+
+variable "list_items_function_name" {
+  type = string
+}
+
+

--- a/terraform/modules/dynamodb/main.tf
+++ b/terraform/modules/dynamodb/main.tf
@@ -1,16 +1,17 @@
 resource "aws_dynamodb_table" "shopping-list" {
-  name = var.dynamo_table_name
+  name         = var.dynamo_table_name
   billing_mode = "PAY_PER_REQUEST"
-  hash_key = var.hash_key_name
-  range_key = var.range_key_name
+  hash_key     = var.hash_key_name
+  range_key    = var.range_key_name
 
   attribute {
-      name = var.hash_key_name
-      type = "S"
+    name = var.hash_key_name
+    type = "S"
   }
 
   attribute {
-      name = var.range_key_name
-      type = "S"
+    name = var.range_key_name
+    type = "S"
   }
 }
+

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "lambda_exec_policy" {
           "lambda:InvokeFunction",
         ],
         Effect   = "Allow",
-        Resource = "*", 
+        Resource = "*",
       },
     ],
   })

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -1,3 +1,8 @@
 output "lambda_function_arn" {
   value = aws_lambda_function.lambda_hello.arn
 }
+
+output "lambda_function_name" {
+  value = aws_lambda_function.lambda_hello.function_name
+}
+

--- a/terraform/modules/lambda_python/iam.tf
+++ b/terraform/modules/lambda_python/iam.tf
@@ -58,3 +58,22 @@ resource "aws_iam_role_policy_attachment" "lambda_dynamodb_attach" {
   role       = aws_iam_role.iam_role_for_lambda.name
   policy_arn = aws_iam_policy.lambda_dynamodb_access_policy.arn
 }
+
+resource "aws_iam_role_policy" "lambda_dynamodb_policy" {
+  name = "${var.function_name}_dynamodb_policy"
+  role = aws_iam_role.iam_role_for_lambda.name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "dynamodb:Query",
+          "dynamodb:GetItem"
+        ],
+        Effect   = "Allow",
+        Resource = var.dynamodb_arn
+      }
+    ]
+  })
+}

--- a/terraform/modules/lambda_python/main.tf
+++ b/terraform/modules/lambda_python/main.tf
@@ -15,9 +15,11 @@ resource "aws_lambda_function" "lambda_py" {
 
 data "archive_file" "lambda_zip" {
   type        = "zip"
-  source_dir  = "${path.root}/../src/lambda/shopping_list/${var.source_dir}"
+  source_dir  = var.source_dir
   output_path = "${path.module}/zip/${var.function_name}.zip"
 
 }
+
+
 
 

--- a/terraform/modules/lambda_python/outputs.tf
+++ b/terraform/modules/lambda_python/outputs.tf
@@ -1,0 +1,8 @@
+output "lambda_function_arn" {
+  value = aws_lambda_function.lambda_py.arn
+}
+
+output "lambda_function_name" {
+  value = aws_lambda_function.lambda_py.function_name
+}
+

--- a/terraform/modules/lambda_python/variables.tf
+++ b/terraform/modules/lambda_python/variables.tf
@@ -10,5 +10,5 @@ variable "source_dir" {
 }
 
 variable "environment_variables" {
-    type = map(string)
+  type = map(string)
 }


### PR DESCRIPTION
**- Adicionado** o código para requisição GET numa lista de tarefas
**- Adicionado** o código que gera a tabela todo-list via Terraform
**- Adicionado** o código que realiza o teste do código da requisição GET
**- Refatorado** o código criado com a lib Black
**- Refatorado** todo o código Terraform já existente e criado utilizando Terraform FMT

Explicação do porque as linhas de código:
dynamodb = boto3.resource("dynamodb")
table = dynamodb.Table(os.environ["DYNAMODB_TABLE_NAME"])
Estarem dentro do bloco TRY e não fora.
A mudança da chamada do boto3 e da table pra dentro do bloco TRY foi necessária para que o testes funcionassem da maneira correta. Já que, sem essa mudança, ao Python carregar o módulo list_items_handler, ele executa tudo no escopo global, então, mesmo que a variável DYNAMO_TABLE_NAME ainda não estivesse definido, ele carregava antes do mock e das variáveis do teste.

![Imagem do WhatsApp de 2025-05-23 à(s) 14 14 51_663aa37d](https://github.com/user-attachments/assets/6ab4a282-d0a6-4eb9-8d63-9e06b0777f7b)
![Imagem do WhatsApp de 2025-05-23 à(s) 12 53 38_10051437](https://github.com/user-attachments/assets/30bc5b35-eb10-4fca-a2e0-751bc51e2846)
![Imagem do WhatsApp de 2025-05-23 à(s) 14 05 55_dbc8f131](https://github.com/user-attachments/assets/c1cf66ee-f9d0-41d2-bc36-093bc97f9c60)

Instruções para teste do código:

- Realize a criação de um usuário cognito
- Realize a autenticação do usuário cognito
- Crie de maneira manual na tabela itens (Necessário a criação manual caso seu código não haja ainda o método POST)

JSON DE CRIAÇÃO:

{
  "PK": { "S": "USER#(Insira aqui o ID DO USUÁRIO(SUB)" },
  "SK": { "S": "ITEM#uuid-1" },
  "title": { "S": "Comprar leite" },
  "description": { "S": "Lembrar de comprar leite no mercado" },
  "done": { "BOOL": false(ou true) }
}

Para saber qual é o Id do usuário, basta clicar nas informações do usuário após confirmado, haverá uma tela parecida com isso

![image](https://github.com/user-attachments/assets/7b6bcf55-4e1d-4e40-a911-9589c9bcce17)

- No postman, realize uma requisição do tipo GET com a Authentication via Bearer Token (Insira o IdToken gerado pela autenticação) e a URL gerada, ex: https://xxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod/lista-tarefa

![Imagem do WhatsApp de 2025-05-23 à(s) 12 52 40_3dbd2fd2](https://github.com/user-attachments/assets/53bd9ead-d4f0-4131-ac67-87811ab8d9a1)


