### PR TITLE
feat(lambda): adiciona suporte ao método PUT na função de update

### DIFF
--- a/src/lambdas/shopping_list/update_item/update_item.py
+++ b/src/lambdas/shopping_list/update_item/update_item.py
@@ -1,40 +1,67 @@
 import json
 import os
+from datetime import date
 
 import boto3
+from boto3.dynamodb.conditions import Attr
 from botocore.exceptions import ClientError
 
 dynamodb = boto3.resource("dynamodb")
-TABLE_NAME = os.environ.get("DYNAMODB_TABLE_NAME")
-table = dynamodb.Table(TABLE_NAME)
+table = dynamodb.Table(os.environ["DYNAMODB_TABLE_NAME"])
 
 
 def lambda_handler(event, context):
-
     try:
-        item_id = event.get("item_id")
-        list_id = event.get("list_id")
+        path_params = event.get("pathParameters", {})
+        item_id = path_params.get("id_do_item")
 
-        if not item_id or not list_id:
-            return response(400, {"message": "item_id e list_id são obrigatórios."})
+        if not item_id:
+            return response(400, {"message": "id_do_item é obrigatório no path."})
 
-        nome = event.get("nome")
-        data = event.get("data")
-        status = event.get("status")
+        body = json.loads(event.get("body", "{}"))
+        if not body:
+            return response(400, {"message": "Corpo da requisição não pode estar vazio."})
+
+        nome = body.get("nome")
+        data = body.get("data")
+        status = body.get("status")
 
         if not (nome or data or status):
-            return response(
-                400, {"message": "Nenhum campo para atualizar foi fornecido."}
-            )
+            return response(400, {"message": "nome, data ou status são obrigatórios"})
 
-        pk = f"LIST#{list_id}"
+        # Encontrar o item existente testando datas próximas
         sk = f"ITEM#{item_id}"
-
-        item = table.get_item(Key={"PK": pk, "SK": sk})
-
-        if "Item" not in item:
+        existing_item, current_pk = find_existing_item(sk)
+        
+        if not existing_item:
             return response(404, {"message": "Item não encontrado."})
 
+        current_data = existing_item["data"]
+        
+        # Se a data está sendo atualizada e é diferente da atual
+        if data and data != current_data:
+            new_list_id = generate_list_id(data)
+            new_pk = f"LIST#{new_list_id}"
+            
+            # Delete old item
+            table.delete_item(Key={"PK": current_pk, "SK": sk})
+            
+            # Create new item 
+            new_item = {
+                "PK": new_pk,
+                "SK": sk,
+                "nome": nome if nome is not None else existing_item["nome"],
+                "data": data,
+                "status": status if status is not None else existing_item["status"],
+            }
+            
+            table.put_item(Item=new_item)
+            return response(200, {"message": "Item atualizado com sucesso.", "item": new_item})
+
+        # Se a data não está mudando, apenas atualiza outros campos
+        pk = current_pk
+        
+        # Build update expression
         update_expression = "SET "
         expression_attribute_names = {}
         expression_attribute_values = {}
@@ -45,11 +72,6 @@ def lambda_handler(event, context):
             expression_attribute_names["#N"] = "nome"
             expression_attribute_values[":n"] = nome
 
-        if data is not None:
-            update_clauses.append("#D = :d")
-            expression_attribute_names["#D"] = "data"
-            expression_attribute_values[":d"] = data
-
         if status is not None:
             if status not in ["TODO", "DONE"]:
                 return response(400, {"message": "Status deve ser 'TODO' ou 'DONE'."})
@@ -59,7 +81,7 @@ def lambda_handler(event, context):
 
         update_expression += ", ".join(update_clauses)
 
-        # Atualizar o item
+        # Update the item
         updated_item = table.update_item(
             Key={"PK": pk, "SK": sk},
             UpdateExpression=update_expression,
@@ -68,15 +90,42 @@ def lambda_handler(event, context):
             ReturnValues="ALL_NEW",
         )
 
-        item = updated_item.get("Attributes", {})
-        return response(200, {"updatedItem": item})
+        return response(200, {"message": "Item atualizado com sucesso.", "item": updated_item.get("Attributes", {})})
 
     except ClientError as e:
-        return response(
-            500, {"message": "Erro no servidor: " + e.response["Error"]["Message"]}
-        )
+        return response(500, {"message": "Erro no servidor: " + e.response["Error"]["Message"]})
     except Exception as ex:
         return response(500, {"message": "Erro interno: " + str(ex)})
+
+
+def find_existing_item(sk):
+    """
+    Tenta encontrar o item existente testando datas próximas à data atual.
+    """
+    today = date.today()
+    
+    # Testa hoje e alguns dias antes/depois
+    for days_offset in range(-7, 8):  
+        test_date = today.replace(day=today.day)
+        try:
+            if days_offset != 0:
+                import datetime
+                test_date = today + datetime.timedelta(days=days_offset)
+        except:
+            continue
+            
+        test_date_str = test_date.strftime("%Y-%m-%d")
+        list_id = generate_list_id(test_date_str)
+        pk = f"LIST#{list_id}"
+        
+        try:
+            item = table.get_item(Key={"PK": pk, "SK": sk})
+            if "Item" in item:
+                return item["Item"], pk
+        except ClientError:
+            continue
+    
+    return None, None
 
 
 def response(status_code, body):
@@ -85,3 +134,7 @@ def response(status_code, body):
         "body": json.dumps(body),
         "headers": {"Content-Type": "application/json"},
     }
+
+
+def generate_list_id(date):
+    return date.replace("-", "")

--- a/src/lambdas/tests/conftest.py
+++ b/src/lambdas/tests/conftest.py
@@ -1,16 +1,18 @@
-import pytest
 import os
-from moto import mock_aws
-import boto3
 import sys
-from unittest.mock import MagicMock 
+import pytest
+import boto3
+from moto import mock_aws
+from unittest.mock import MagicMock
 
+# Adiciona o diretório 'src/' ao sys.path
 current_dir = os.path.dirname(os.path.abspath(__file__))
-src_path = os.path.abspath(os.path.join(current_dir, "..", ".."))
+src_path = os.path.abspath(os.path.join(current_dir, "..", "..", "src"))
 if src_path not in sys.path:
     sys.path.insert(0, src_path)
 
-os.environ["DYNAMODB_TABLE_NAME"] = "test-mock-table"   
+# Define variável de ambiente usada no código
+os.environ["DYNAMODB_TABLE_NAME"] = "test-mock-table"
 
 @pytest.fixture
 def mock_event():
@@ -18,44 +20,36 @@ def mock_event():
         "requestContext": {"authorizer": {"jwt": {"claims": {"sub": "test_user_id"}}}}
     }
 
-
 @pytest.fixture
 def mocked_list_items_table(monkeypatch):
-    
-    import lambdas.todo_list.list_items.list_items_handler as list_items_module
+    import lambdas.shopping_list.list_items.list_items_handler as list_items_module
 
     mock_table_instance = MagicMock()
-
     mock_table_instance.query.return_value = {
         "Items": [{"PK": "USER#test_user_id", "SK": "ITEM#123", "data": "sample"}]
     }
 
     monkeypatch.setattr(list_items_module, "table", mock_table_instance)
-
     yield mock_table_instance
 
 @pytest.fixture(scope="session")
 def aws_credentials():
-    
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
-
 @pytest.fixture(scope="function")
 def dynamodb_resource_and_name(aws_credentials):
-   
     original_table_name = os.environ.get("DYNAMODB_TABLE_NAME")
-    
-    moto_table_name = "test-shopping-list-table" 
+    moto_table_name = "test-shopping-list-table"
     os.environ["DYNAMODB_TABLE_NAME"] = moto_table_name
 
-    with mock_aws(): 
+    with mock_aws():
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-        
-        try: # Adiciona um bloco try para lidar com a criação de tabela
+
+        try:
             table = dynamodb.create_table(
                 TableName=moto_table_name,
                 KeySchema=[
@@ -70,13 +64,69 @@ def dynamodb_resource_and_name(aws_credentials):
             )
             table.wait_until_exists()
         except dynamodb.meta.client.exceptions.ResourceInUseException:
-            
             table = dynamodb.Table(moto_table_name)
-        
+
         yield dynamodb, moto_table_name
-    
+
     if original_table_name is not None:
         os.environ["DYNAMODB_TABLE_NAME"] = original_table_name
     else:
-        if "DYNAMODB_TABLE_NAME" in os.environ:
-            del os.environ["DYNAMODB_TABLE_NAME"]
+        os.environ.pop("DYNAMODB_TABLE_NAME", None)
+
+@pytest.fixture
+def mock_dynamodb(monkeypatch):
+    from lambdas.shopping_list.update_item import update_item as update_item_module
+
+    mock_table = MagicMock()
+
+    def mock_get_item(Key):
+        if Key["SK"] == "ITEM#11338bc0-004e-42fa-bdb8-f3989a641612":
+            return {
+                "Item": {
+                    "PK": Key["PK"],
+                    "SK": Key["SK"],
+                    "nome": "Tarefa Teste",
+                    "data": "2025-05-29",
+                    "status": "TODO"
+                }
+            }
+        return {}
+
+    def mock_get_item_not_found(Key):
+        return {}
+
+    def mock_update_item(**kwargs):
+        values = kwargs.get("ExpressionAttributeValues", {})
+        pk = kwargs["Key"]["PK"]
+        sk = kwargs["Key"]["SK"]
+
+        # Dados simulados do item atual no banco
+        current_item = {
+            "PK": pk,
+            "SK": sk,
+            "nome": "Tarefa Teste",
+            "data": "2025-05-29",
+            "status": "TODO"
+        }
+
+        # Aplica os novos valores enviados
+        for key_alias, value in values.items():
+            field = key_alias[1:]
+            if field == "n":
+                current_item["nome"] = value
+            elif field == "d":
+                current_item["data"] = value
+            elif field == "s":
+                current_item["status"] = value
+
+        return {"Attributes": current_item}
+
+    mock_table.get_item.side_effect = mock_get_item
+    mock_table.update_item.side_effect = mock_update_item
+
+    monkeypatch.setattr(update_item_module, "table", mock_table)
+
+    return {
+        "table": mock_table,
+        "get_item_not_found": mock_get_item_not_found
+    }

--- a/src/lambdas/tests/test_item_handler.py
+++ b/src/lambdas/tests/test_item_handler.py
@@ -1,6 +1,6 @@
 import json
 
-from lambdas.todo_list.list_items.list_items_handler import lambda_handler
+from lambdas.shopping_list.list_items.list_items_handler import lambda_handler
 
 def test_lambda_handler_success(mock_event, mocked_list_items_table):
     

--- a/src/lambdas/tests/test_update_item.py
+++ b/src/lambdas/tests/test_update_item.py
@@ -1,0 +1,88 @@
+import json
+import pytest
+from lambdas.shopping_list.update_item.update_item import lambda_handler
+
+
+def extract_message(result):
+    """ Helper para decodificar body e extrair mensagem """
+    return json.loads(result["body"]).get("message", "")
+
+
+def test_missing_id_do_item(mock_event):
+    event = {
+        "pathParameters": {},
+        "body": json.dumps({"nome": "Nova tarefa"})
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 400
+    assert "id_do_item" in extract_message(result)
+
+
+def test_empty_body(mock_event):
+    event = {
+        "pathParameters": {"id_do_item": "123"},
+        "body": "{}"
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 400
+    assert "Corpo da requisição" in extract_message(result)
+
+
+def test_missing_all_fields(mock_event):
+    event = {
+        "pathParameters": {"id_do_item": "123"},
+        "body": json.dumps({})  # vazio → cairá no if not body
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 400
+    assert "Corpo da requisição" in extract_message(result)
+
+
+def test_update_status_only(mock_event, mock_dynamodb):
+    event = {
+        "pathParameters": {"id_do_item": "11338bc0-004e-42fa-bdb8-f3989a641612"},
+        "body": json.dumps({"status": "DONE"})
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["item"]["status"] == "DONE"
+
+
+def test_update_nome_and_status(mock_event, mock_dynamodb):
+    event = {
+        "pathParameters": {"id_do_item": "11338bc0-004e-42fa-bdb8-f3989a641612"},
+        "body": json.dumps({"nome": "Nova Tarefa", "status": "TODO"})
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["item"]["nome"] == "Nova Tarefa"
+
+
+def test_invalid_status_value(mock_event, mock_dynamodb):
+    event = {
+        "pathParameters": {"id_do_item": "11338bc0-004e-42fa-bdb8-f3989a641612"},
+        "body": json.dumps({"status": "INVALID"})
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 400
+    assert "Status deve ser" in extract_message(result)
+
+
+def test_item_not_found(mock_event, monkeypatch):
+    from lambdas.shopping_list.update_item import update_item as update_item_module
+
+    def not_found_get_item(Key):
+        return {}
+
+    mock_table = update_item_module.table
+    monkeypatch.setattr(mock_table, "get_item", not_found_get_item)
+
+    event = {
+        "pathParameters": {"id_do_item": "nao_existe"},
+        "body": json.dumps({"nome": "Qualquer coisa"})
+    }
+    result = lambda_handler(event, {})
+    assert result["statusCode"] == 404
+    assert "Item não encontrado" in extract_message(result)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,18 +78,18 @@ module "list-items" {
 }
 
 module "api_gateway" {
-  source                     = "./modules/apigateway"
-  lambda_function_arn        = module.hello-terraform.lambda_function_arn
-  lambda_function_name       = module.hello-terraform.lambda_function_name
-  list_items_function_arn    = module.list-items.lambda_function_arn
-  list_items_function_name   = module.list-items.lambda_function_name
-  add_item_function_arn      = module.add-item.lambda_function_arn
-  add_item_function_name     = module.add-item.lambda_function_name
-  update_item_function_arn   = module.update-item.lambda_function_arn
-  update_item_function_name  = module.update-item.lambda_function_name
-  user_pool_id               = module.cognito.cognito_user_pool
-  user_pool_client_id        = module.cognito.cognito_user_pool_client
-  region                     = var.region
+  source                    = "./modules/apigateway"
+  lambda_function_arn       = module.hello-terraform.lambda_function_arn
+  lambda_function_name      = module.hello-terraform.lambda_function_name
+  list_items_function_arn   = module.list-items.lambda_function_arn
+  list_items_function_name  = module.list-items.lambda_function_name
+  add_item_function_arn     = module.add-item.lambda_function_arn
+  add_item_function_name    = module.add-item.lambda_function_name
+  update_item_function_arn  = module.update-item.lambda_function_arn
+  update_item_function_name = module.update-item.lambda_function_name
+  user_pool_id              = module.cognito.cognito_user_pool
+  user_pool_client_id       = module.cognito.cognito_user_pool_client
+  region                    = var.region
 }
 
 output "cognito_user_pool_id" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,19 +64,6 @@ module "remove-item" {
 }
 
 
-module "api_gateway" {
-  source                   = "./modules/apigateway"
-  lambda_function_arn      = module.hello-terraform.lambda_function_arn
-  lambda_function_name     = module.hello-terraform.lambda_function_name
-  list_items_function_arn  = module.list-items.lambda_function_arn
-  list_items_function_name = module.list-items.lambda_function_name
-  add_item_function_arn    = module.add-item.lambda_function_arn
-  add_item_function_name   = module.add-item.lambda_function_name
-  user_pool_id             = module.cognito.cognito_user_pool
-  user_pool_client_id      = module.cognito.cognito_user_pool_client
-  region                   = var.region
-}
-
 module "list-items" {
   source         = "./modules/lambda_python"
   function_name  = "list_items"
@@ -90,6 +77,20 @@ module "list-items" {
   }
 }
 
+module "api_gateway" {
+  source                     = "./modules/apigateway"
+  lambda_function_arn        = module.hello-terraform.lambda_function_arn
+  lambda_function_name       = module.hello-terraform.lambda_function_name
+  list_items_function_arn    = module.list-items.lambda_function_arn
+  list_items_function_name   = module.list-items.lambda_function_name
+  add_item_function_arn      = module.add-item.lambda_function_arn
+  add_item_function_name     = module.add-item.lambda_function_name
+  update_item_function_arn   = module.update-item.lambda_function_arn
+  update_item_function_name  = module.update-item.lambda_function_name
+  user_pool_id               = module.cognito.cognito_user_pool
+  user_pool_client_id        = module.cognito.cognito_user_pool_client
+  region                     = var.region
+}
 
 output "cognito_user_pool_id" {
   value = module.cognito.cognito_user_pool

--- a/terraform/modules/apigateway/main.tf
+++ b/terraform/modules/apigateway/main.tf
@@ -97,16 +97,16 @@ resource "aws_lambda_permission" "list_items_api_permission" {
 resource "aws_apigatewayv2_integration" "add_item_integration" {
   api_id                 = aws_apigatewayv2_api.api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = var.add_item_function_arn 
-  integration_method     = "POST" 
+  integration_uri        = var.add_item_function_arn
+  integration_method     = "POST"
   payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_route" "add_item_route" {
-  api_id             = aws_apigatewayv2_api.api.id
-  route_key          = "POST /lista-tarefa" 
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "POST /lista-tarefa"
 
-  authorization_type = "JWT" 
+  authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.cognito_authorizer.id
 
   target = "integrations/${aws_apigatewayv2_integration.add_item_integration.id}"
@@ -115,7 +115,7 @@ resource "aws_apigatewayv2_route" "add_item_route" {
 resource "aws_lambda_permission" "add_item_api_permission" {
   statement_id  = "AllowAPIGatewayInvokeAddItem"
   action        = "lambda:InvokeFunction"
-  function_name = var.add_item_function_name 
+  function_name = var.add_item_function_name
   principal     = "apigateway.amazonaws.com"
 }
 

--- a/terraform/modules/apigateway/main.tf
+++ b/terraform/modules/apigateway/main.tf
@@ -119,6 +119,32 @@ resource "aws_lambda_permission" "add_item_api_permission" {
   principal     = "apigateway.amazonaws.com"
 }
 
+resource "aws_apigatewayv2_integration" "update_item_integration" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = var.update_item_function_arn
+  integration_method     = "PUT"
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "update_item_route" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "PUT /lista-tarefa/{id_do_item}"
+
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito_authorizer.id
+
+  target = "integrations/${aws_apigatewayv2_integration.update_item_integration.id}"
+}
+
+resource "aws_lambda_permission" "update_item_api_permission" {
+  statement_id  = "AllowAPIGatewayInvokeUpdateItem"
+  action        = "lambda:InvokeFunction"
+  function_name = var.update_item_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*/lista-tarefa/*"
+}
+
 output "api_url" {
   value = aws_apigatewayv2_stage.stage.invoke_url
 }

--- a/terraform/modules/apigateway/variables.tf
+++ b/terraform/modules/apigateway/variables.tf
@@ -23,3 +23,12 @@ variable "add_item_function_name" {
   type        = string
 }
 
+variable "update_item_function_arn" {
+  description = "ARN da função Lambda que atualiza um item (update_item.py)"
+  type        = string
+}
+
+variable "update_item_function_name" {
+  description = "Nome da função Lambda que atualiza um item (update_item.py)"
+  type        = string
+}

--- a/terraform/modules/lambda_python/iam.tf
+++ b/terraform/modules/lambda_python/iam.tf
@@ -17,6 +17,7 @@ resource "aws_iam_role" "iam_role_for_lambda" {
 EOF
 }
 
+
 resource "aws_iam_policy" "lambda_dynamodb_access_policy" {
   name        = "${var.function_name}-dynamodb-policy"
   description = "Permite que a Lambda acesse a tabela DynamoDB específica"


### PR DESCRIPTION
Atualizei a lógica da Lambda para permitir a edição de um item da lista de tarefas, conforme especificado

Implementei testes unitários cobrindo cenários de sucesso e falha (todos passaram)

Atualizei a configuração do API Gateway para aceitar requisições PUT no endpoint:
PUT /lista-tarefa/{id_do_item}


![test_unit_kassia](https://github.com/user-attachments/assets/a75c1411-870c-4f68-89ee-2a3c6406647a)
